### PR TITLE
Replaced sapply

### DIFF
--- a/R/all_functions.R
+++ b/R/all_functions.R
@@ -608,7 +608,7 @@ LoadTiff <- function(tiff_file, experiment = NULL, condition = NULL, replicate =
 
   # Get image matrices
   FinalImage <- try({lapply(myIMG, function(x) {
-    sapply(1:ncol(x), function(ii) {as.numeric(x[,ii])})
+    vapply(seq_len(ncol(x)), function(ii) {as.numeric(x[,ii])}, FUN.VALUE = numeric(nrow(x)))
   })}, silent = TRUE)
 
   #return(list(images = FinalImage,


### PR DESCRIPTION
Please verify this one. I do not have an example image, so could not run the code and had to make a qualified guess that the return value has length given by the number of rows of `x`, and is a `numeric`, aka `double`.