### PR TITLE
Set threads=1 on vignette

### DIFF
--- a/vignettes/cellmigRation.Rmd
+++ b/vignettes/cellmigRation.Rmd
@@ -95,7 +95,7 @@ Damiano Fantini (Northwestern University, Chicago, IL, USA); Salim Ghannoum
 
 ### More resources
 
-- An exhaustive vignette is available at: 
+- An exhaustive vignette is available at:
 <https://www.data-pulse.com/projects/2020/cellmigRation/cellmigRation_v01.html>
 
 - GitHub page: <https://github.com/ocbe-uio/cellmigRation>
@@ -134,7 +134,7 @@ library(kableExtra)
 #### Importing TIFF files
 
 In this vignette, we are going to analyze three images with the aim of
-illustrating the functions included in *cellmigRation*. 
+illustrating the functions included in *cellmigRation*.
 The original TIFF files are available at the following URLs:
 
 - <https://www.data-pulse.com/projects/2020/cellmigRation/ctrl_001.tif>
@@ -144,11 +144,11 @@ The original TIFF files are available at the following URLs:
 - <https://www.data-pulse.com/projects/2020/cellmigRation/drug_001.tif>
 
 
-**Note**. TIFF files can be imported using the `LoadTiff()` function. 
-This function includes a series of (optional) arguments to attach 
-meta-information to a TIFF image, for example the `experiment` and 
-`condition` arguments. Imported numeric images are stored as 
-a *trackedCells*-class object. 
+**Note**. TIFF files can be imported using the `LoadTiff()` function.
+This function includes a series of (optional) arguments to attach
+meta-information to a TIFF image, for example the `experiment` and
+`condition` arguments. Imported numeric images are stored as
+a *trackedCells*-class object.
 
 Three sample `trackedCells` objects (imported from the corresponding TIFF files)
 are available as a list in the `cellmigRation` package
@@ -199,8 +199,8 @@ the *pick #1* is selected for the downstream steps.
 ```{r echo=TRUE, include=TRUE, eval=TRUE, fig.height=7.8}
 # Optimize parameters using 2 cores
 x1 <- OptimizeParams(
-    ThreeConditions$ctrl01, threads = 2, lnoise_range = c(5, 12),
-    diameter_range = c(16, 22), threshold_range = c(5, 15, 30), 
+    ThreeConditions$ctrl01, threads = 1, lnoise_range = c(5, 12),
+    diameter_range = c(16, 22), threshold_range = c(5, 15, 30),
     verbose = FALSE, plot = TRUE)
 ```
 
@@ -249,7 +249,7 @@ x1 <- CellTracker(
 # Track cell movements using params from a different object
 x2 <- CellTracker(
     ThreeConditions$ctrl02, import_optiParam_from = x1,
-    min_frames_per_cell = 3, threads = 2)
+    min_frames_per_cell = 3, threads = 1)
 ```
 
 ```{r fig.height=4, fig.width=4, fig.align='center'}
@@ -257,7 +257,7 @@ x2 <- CellTracker(
 x3 <- CellTracker(
     tc_obj = ThreeConditions$drug01,
     lnoise = 5, diameter = 22, threshold = 6,
-    threads = 2, maxDisp = 10,
+    threads = 1, maxDisp = 10,
     show_plots = TRUE)
 ```
 
@@ -473,17 +473,17 @@ following metrics:
 
 - Velocity AutoCorrelation: `VeAutoCor()` function
 
-These steps are meant to be run on larger datasets, including a larger number 
-of cells. Here, we only show an example of how to run a *DiRatio* analysis, 
-an *MSD* analysis and *Velocity autocorrelation*. 
+These steps are meant to be run on larger datasets, including a larger number
+of cells. Here, we only show an example of how to run a *DiRatio* analysis,
+an *MSD* analysis and *Velocity autocorrelation*.
 
 **For more examples about Deep Trajectory Analysis, please visit:**
 <https://www.data-pulse.com/projects/2020/cellmigRation/cellmigRation_v01.html>
 
 
-**Directionality Analysis**. This analysis is performed via the `DiRatio()` 
-function. Results are saved in a *CSV* file. Plots can be generated using the 
-`DiRatioPlot()` function. Plots are saved in a newly created folder with the 
+**Directionality Analysis**. This analysis is performed via the `DiRatio()`
+function. Results are saved in a *CSV* file. Plots can be generated using the
+`DiRatioPlot()` function. Plots are saved in a newly created folder with the
 following extension: `-DR_Results`.
 
 
@@ -536,7 +536,7 @@ rmTD <-FinRes(rmTD, ParCor=TRUE, export=FALSE)
 Below, the first 5 columns of the output data.frame are shown.
 
 ```{r echo=FALSE, include=TRUE, results='asis'}
-head(getCellMigSlot(rmTD, "results"), 5) %>% 
+head(getCellMigSlot(rmTD, "results"), 5) %>%
     kable() %>% kable_styling(bootstrap_options = 'striped')
 ```
 
@@ -545,7 +545,7 @@ head(getCellMigSlot(rmTD, "results"), 5) %>%
 The `CellMigPCA()` function automatically generates Principal Component Analysis
 based on a set of parameters selected by the user.
 The `CellMigPCAclust()` function automatically generates clusters based on the
-Principal Component Analysis. This analysis is supposed to be run in an 
+Principal Component Analysis. This analysis is supposed to be run in an
 interactive session via the `CellMigPCA()` function.
 
 

--- a/vignettes/cellmigRation.Rmd
+++ b/vignettes/cellmigRation.Rmd
@@ -192,9 +192,11 @@ for each argument based on the empirical distribution of signal and sizes of
 particles detected in the frame with median signal from a TIFF stack. This
 operation supports parallelization.
 
-**Note**: the user may request to visualize a plot. The output plot shows how
+**Note 1**: the user may request to visualize a plot. The output plot shows how
 many cells were detected for each combination of parameter values. By default,
 the *pick #1* is selected for the downstream steps.
+
+**Note 2**: for larger datasets, the user may wish to set the `threads` argument below to a larger integer in order to benefit from paralellized operations. A theoretical upper bound to this argument would be the number of threads in your CPU---which you can check with `parallel::detectCores()`---, but it is considered good practice to leave at least one thread for other system operations.
 
 ```{r echo=TRUE, include=TRUE, eval=TRUE, fig.height=7.8}
 # Optimize parameters using 2 cores


### PR DESCRIPTION
PR motivated by conversation on Issue #69 and an attempt to make the vignette more universally-reproducible. Changes made:

- Set threads to 1 (fixes #69), removed whitespace
- Added note on parallelization
